### PR TITLE
expand LTS into Long Term Support more on homepage

### DIFF
--- a/homepage.html
+++ b/homepage.html
@@ -33,8 +33,8 @@
     <div class="row">
       <div class="span6">
         <p>
-          Stackage is a stable source of Haskell packages. We guarantee that
-          packages build and pass tests before generating nightly and LTS
+          Stackage is a stable source of Haskell packages. We guarantee that 
+          packages build consistently and pass tests before generating nightly and Long Term Support (LTS)
           releases.
         </p>
         <h2>Why</h2>
@@ -62,7 +62,7 @@ $ cabal install</pre>
       <div class="span12">
         <h2>Get Started</h2>
         <ul>
-          <li><a href="/lts">LTS Haskell</a> (<a href="https://github.com/fpco/lts-haskell#readme">what is LTS Haskell?</a>)</li>
+          <li><a href="/lts">LTS Haskell</a> (<a href="https://github.com/fpco/lts-haskell#readme">what is Long Term Support Haskell?</a>)</li>
           <li><a href="/nightly">Stackage Nightly</a></li>
         </ul>
         <p>


### PR DESCRIPTION
I feel this makes it clearer for new folk to understand what LTS Haskell is.