### PR TITLE
stack-setup.yaml: upgrade to ghc-7.10.2

### DIFF
--- a/stack/stack-setup.yaml
+++ b/stack/stack-setup.yaml
@@ -46,6 +46,11 @@ ghc:
             url: "https://www.haskell.org/ghc/dist/7.8.4/ghc-7.8.4-i386-unknown-linux-centos65.tar.xz"
             content-length: 61873796
             sha1: 0ec1f10b38e1e94b41e260855f4744f271f462f2
+        7.10:
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-i386-unknown-linux-centos66.tar.xz"
+            content-length: 87824296
+            sha1: f37d2a1323c191ef9372e1256220691ec2f84b40
 
     linux64-gmp4:
         7.8:
@@ -53,6 +58,11 @@ ghc:
             url: "https://www.haskell.org/ghc/dist/7.8.4/ghc-7.8.4-x86_64-unknown-linux-centos65.tar.xz"
             content-length: 61654528
             sha1: d204e2a1344734d1f60c79cf330b5e3f40b672a0
+        7.10:
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-x86_64-unknown-linux-centos66.tar.xz"
+            content-length: 88804220
+            sha1: e6f128245d66cd53711b1829122b38ba8ded70f1
 
     macosx:
         7.8:

--- a/stack/stack-setup.yaml
+++ b/stack/stack-setup.yaml
@@ -122,10 +122,10 @@ ghc:
             content-length: 68504948
             sha1: fa6164a1408b94c719957b23f043da8539376351
         7.10:
-            version: 7.10.1
-            url: "https://www.haskell.org/ghc/dist/7.10.1/ghc-7.10.1-i386-portbld-freebsd.tar.xz"
-            content-length: 75523240
-            sha1: 5dd18c6a5c2da422dc1784720c7948f4e25b7f70
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-i386-portbld-freebsd.tar.xz"
+            content-length: 87968692
+            sha1: 6925a297932d1922f8e6c9f4ad0f0ccbdd3ea5b9
 
     freebsd64:
         7.8:
@@ -134,10 +134,10 @@ ghc:
             content-length: 68223736
             sha1: 3507549290a8226febb1284a50c51a5f10261d94
         7.10:
-            version: 7.10.1
-            url: "https://www.haskell.org/ghc/dist/7.10.1/ghc-7.10.1-x86_64-portbld-freebsd.tar.xz"
-            content-length: 76047456
-            sha1: e1d9d07bb8806f1b7d6ba110471aa24442e881dc
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-x86_64-portbld-freebsd.tar.xz"
+            content-length: 88841932
+            sha1: 43372109b84f55cf9138982f84f39cd178d95975
 
     # Untested so far, see: https://github.com/commercialhaskell/stack/issues/416#issuecomment-115553835
     openbsd64:

--- a/stack/stack-setup.yaml
+++ b/stack/stack-setup.yaml
@@ -23,10 +23,10 @@ ghc:
             content-length: 69743420
             sha1: a5d4f65b9b063eae476657cb9b93277609c42cf1
         7.10:
-            version: 7.10.1
-            url: "https://www.haskell.org/ghc/dist/7.10.1/ghc-7.10.1-i386-unknown-linux-deb7.tar.xz"
-            content-length: 78546928
-            sha1: aa87ce310b966ac6836f30b8dd4ecfd0b9d2ba0d
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-i386-unknown-linux-deb7.tar.xz"
+            content-length: 90779224
+            sha1: d02d88a2049fb7e9e375c54013a40229b41758f2
 
     linux64:
         7.8:
@@ -35,10 +35,10 @@ ghc:
             content-length: 70325112
             sha1: 11aec12d4bb27f6fa59dcc8535a7a3b3be8cb787
         7.10:
-            version: 7.10.1
-            url: "https://www.haskell.org/ghc/dist/7.10.1/ghc-7.10.1-x86_64-unknown-linux-deb7.tar.xz"
-            content-length: 78610472
-            sha1: c256f5975613ab49aeb2375b1e60cd8a348ed404
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-x86_64-unknown-linux-deb7.tar.xz"
+            content-length: 91852904
+            sha1: c32eff3ecb16eeb9a8682ae2222574a6d1a68bc1
 
     linux32-gmp4:
         7.8:
@@ -61,10 +61,10 @@ ghc:
             content-length: 129602990
             sha1: b7aff3983e9005b74d90c5a4fd7c837f9e752923
         7.10:
-            version: 7.10.1
-            url: "https://www.haskell.org/ghc/dist/7.10.1/ghc-7.10.1-x86_64-apple-darwin.tar.bz2"
-            content-length: 146558980
-            sha1: 5c7282f955020e92dc83560af9e7e3eadc2bd58f
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-x86_64-apple-darwin.tar.bz2"
+            content-length: 146921830
+            sha1: 0a043340952fad211f4c9780bde873e0d9e4d331
 
     windowsintegersimple32:
         7.10:
@@ -87,10 +87,10 @@ ghc:
             content-length: 75057588
             sha1: 9acfb321f1f8bbfcb6d6b58f6d88fe93f0abaf63
         7.10:
-            version: 7.10.1
-            url: "https://www.haskell.org/ghc/dist/7.10.1/ghc-7.10.1-i386-unknown-mingw32.tar.xz"
-            content-length: 83338828
-            sha1: adba4e5912064bf65c410c9516849efd3e337c09
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-i386-unknown-mingw32.tar.xz"
+            content-length: 103096112
+            sha1: e7dd5be85f5fb7f1fe90c590cfe354787472b715
 
     # Not currently used, but may as well add it
     windows64:
@@ -100,10 +100,10 @@ ghc:
             content-length: 92141344
             sha1: cec5b4c4fe612ac1fe9302f491ae58ac44812b26
         7.10:
-            version: 7.10.1
-            url: "https://www.haskell.org/ghc/dist/7.10.1/ghc-7.10.1-x86_64-unknown-mingw32.tar.xz"
-            content-length: 100171232
-            sha1: 21dbe6ce2e613c738d604993f71cd4368e227fc0
+            version: 7.10.2
+            url: "https://www.haskell.org/ghc/dist/7.10.2/ghc-7.10.2-x86_64-unknown-mingw32.tar.xz"
+            content-length: 134230828
+            sha1: 5372a4ed3cb393bed7e1b0e0c454ecb051e85ddd
 
     freebsd32:
         7.8:


### PR DESCRIPTION
Getting 403 forbidden when trying to download the FreeBSD binaries, so not updated yet.

@3noch: are you planning to make `mingw32-integer-simple` for ghc-7.10.2?