### PR TITLE
Removing incorrect comment: GHC for 64-bit Windows is used

### DIFF
--- a/stack/stack-setup.yaml
+++ b/stack/stack-setup.yaml
@@ -102,7 +102,6 @@ ghc:
             content-length: 103096112
             sha1: e7dd5be85f5fb7f1fe90c590cfe354787472b715
 
-    # Not currently used, but may as well add it
     windows64:
         7.8:
             version: 7.8.4


### PR DESCRIPTION
It is possible for `stack` flags and `stack.yaml` to demand a 64-bit build of GHC for Windows and it does in fact work. This business about 64-bit GHC on Windows not being safe is a rumor that I have yet to see proven. I use it every day. In fact I have production code running on Windows that was built with 64-bit GHC.