### PR TITLE
Change Stack links to its README

### DIFF
--- a/homepage.html
+++ b/homepage.html
@@ -61,7 +61,7 @@
           <h2>Quick start</h2>
           <ol>
             <li>
-              Download and install <a href="https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md">stack</a>.</li>
+              Download and install <a href="https://github.com/commercialhaskell/stack#readme">Stack</a>.</li>
             <li>
               Run <code>stack build</code>
             </li>

--- a/install.md
+++ b/install.md
@@ -2,13 +2,11 @@
 <div class="row">
 <div class="span12">
 
-# Install stack
+# Install Stack
 
 The recommended method for getting up and running is to [install
-stack](https://github.com/commercialhaskell/stack/blob/master/doc/install_and_upgrade.md). You can find
-out more information about stack on [the stack
-homepage](https://github.com/commercialhaskell/stack#readme). As a quick
-overview: stack is a full-featured Haskell build tool that will install
+Stack](https://github.com/commercialhaskell/stack#readme). As a quick
+overview: Stack is a full-featured Haskell build tool that will install
 necessary build tools (like the Glasgow Haskell Compiler- GHC), and is
 preloaded with support for Stackage snapshots- both LTS Haskell and Stackage
 Nightly.


### PR DESCRIPTION
The README is a nicer portal for installing than
install_and_upgrade.md.

Also, capitalize Stack.