### PR TITLE
Remove broken GHC-7.8.3-bindist

### DIFF
--- a/stack/stack-setup-2.yaml
+++ b/stack/stack-setup-2.yaml
@@ -294,10 +294,6 @@ ghc:
             
     # Untested so far, see: https://github.com/commercialhaskell/stack/issues/416#issuecomment-115553835
     openbsd64:
-        7.8.3:
-            url: "https://openbsd.dead-parrot.de/distfiles/ghc-7.8.3.20150623-amd64-unknown-openbsd.tar.bz2"
-            content-length: 56087622
-            sha1: 33e5d2fcc9be1e3123002ba06f76a3f4989c23a9
         7.10.3:
             # Originally from https://haskell.sru-systems.com/ghc-7.10.3-openbsd-x86_64-current.tar.bz2
             # provided by https://github.com/mrijkeboer


### PR DESCRIPTION
Reported broken at https://github.com/commercialhaskell/stack/pull/2456#issuecomment-238336954, and not usable at https://github.com/commercialhaskell/stack/issues/416#issuecomment-115621586.
Removal was suggested in https://github.com/commercialhaskell/stack/issues/416#issuecomment-220801230.