### PR TITLE
Support multiple OpenBSD versions

### DIFF
--- a/stack/stack-setup-2.yaml
+++ b/stack/stack-setup-2.yaml
@@ -576,6 +576,12 @@ ghc:
             content-length: 115142184
             sha1: b9bac0f843687facc11cefe3a59d465c780e2e67
 
+    openbsd64-maj6-min1:
+        8.2.1:
+            url: "https://downloads.haskell.org/~ghc/8.2.1/ghc-8.2.1-x86_64-openbsd61-openbsd.tar.xz"
+            content-length: 115110128
+            sha1: 5ac8a867cf1241eeebdef7a6eee74f0a55e4543e
+
     # This block is not very useful, but ensures compatibility for people who do not specify ghc-build by hand.
     openbsd64:
         # This bindist of 7.10.3 has some issues, see https://github.com/commercialhaskell/stack/issues/416#issuecomment-220797513

--- a/stack/stack-setup-2.yaml
+++ b/stack/stack-setup-2.yaml
@@ -578,7 +578,7 @@ ghc:
 
     openbsd64-maj6-min1:
         8.2.1:
-            url: "https://downloads.haskell.org/~ghc/8.2.1/ghc-8.2.1-x86_64-openbsd61-openbsd.tar.xz"
+            url: "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.2.1-release/ghc-8.2.1-x86_64-openbsd61-openbsd.tar.xz"
             content-length: 115110128
             sha1: 5ac8a867cf1241eeebdef7a6eee74f0a55e4543e
 

--- a/stack/stack-setup-2.yaml
+++ b/stack/stack-setup-2.yaml
@@ -582,7 +582,7 @@ ghc:
             content-length: 115110128
             sha1: 5ac8a867cf1241eeebdef7a6eee74f0a55e4543e
 
-    # This block is not very useful, but ensures compatibility for people who do not specify ghc-build by hand.
+    # This block is not very useful, but ensures compatibility for people with older Stack releases who do not specify ghc-build by hand.
     openbsd64:
         # This bindist of 7.10.3 has some issues, see https://github.com/commercialhaskell/stack/issues/416#issuecomment-220797513
         7.10.3:

--- a/stack/stack-setup-2.yaml
+++ b/stack/stack-setup-2.yaml
@@ -554,6 +554,29 @@ ghc:
             content-length: 124245556
             sha1: 2c928c5c367df1397eeba416566587858f8f7d74
 
+    # OpenBSD releases are not binary compatible. For each release, we need a separate block, called `openbsd64-$GhcBuild`,
+    # with any bindists available for that OpenBSD release. `$GhcBuild` encodes the OpenBSD release number.
+    # For instance, OpenBSD 5.9, 6.0, and 6.1 would have blocks called openbsd64-maj5-min9, openbsd64-maj6-min0, openbsd64-maj6-min1.
+    # The value `$GhcBuild` is not autodetected in Stack 1.5.0, only after https://github.com/commercialhaskell/stack/pull/3184;
+    # for earlier Stack releases, `$GhcBuild` should be specified by hand using the `ghc-build` YAML field:
+    # https://docs.haskellstack.org/en/stable/yaml_configuration/#ghc-build
+    openbsd64-maj5-min9:
+        8.0.1:
+            url: "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.0.1-release/ghc-8.0.1-x86_64-unknown-openbsd5.9.tar.xz"
+            content-length: 100619184
+            sha1: 7ed707de43456ddc4534f68a17ef58b7099e9a59
+        8.0.2:
+            url: "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.0.2-release/ghc-8.0.2-x86_64-unknown-openbsd.tar.xz"
+            content-length: 100054832
+            sha1: 426b01e6ac72b5e039eb9626649506bc47eb9510
+
+    openbsd64-maj6-min0:
+        8.2.1:
+            url: "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.2.1-release/ghc-8.2.1-x86_64-openbsd60-openbsd.tar.xz"
+            content-length: 115142184
+            sha1: b9bac0f843687facc11cefe3a59d465c780e2e67
+
+    # This block is not very useful, but ensures compatibility for people who do not specify ghc-build by hand.
     openbsd64:
         # This bindist of 7.10.3 has some issues, see https://github.com/commercialhaskell/stack/issues/416#issuecomment-220797513
         7.10.3:


### PR DESCRIPTION
Sketch a different setup for OpenBSD: use OpenBSD release as ghc-build identifier. See comments for details.

Should ideally be merged before https://github.com/commercialhaskell/stack/pull/3184.