### PR TITLE
Fix #45: Add `Win32` to `global-hints.yaml`

### DIFF
--- a/stack/global-hints.yaml
+++ b/stack/global-hints.yaml
@@ -35,6 +35,7 @@ ghc-8.4.2:
   pretty: '1.1.3.6'
   template-haskell: '2.13.0.0'
   directory: '1.3.1.5'
+  Win32: '2.6.1.0'
 ghc-8.0.1:
   ghc: '8.0.1'
   hoopl: '3.10.2.1'
@@ -63,6 +64,7 @@ ghc-8.0.1:
   pretty: '1.1.3.3'
   template-haskell: '2.11.0.0'
   directory: '1.2.6.2'
+  Win32: '2.3.1.1'
 ghc-8.2.2:
   ghc: '8.2.2'
   hoopl: '3.10.2.2'
@@ -92,6 +94,7 @@ ghc-8.2.2:
   pretty: '1.1.3.3'
   template-haskell: '2.12.0.0'
   directory: '1.3.0.2'
+  Win32: '2.5.4.1'
 ghc-8.4.1:
   ghc: '8.4.1'
   bytestring: '0.10.8.2'
@@ -124,6 +127,7 @@ ghc-8.4.1:
   pretty: '1.1.3.6'
   template-haskell: '2.13.0.0'
   directory: '1.3.1.5'
+  Win32: '2.6.1.0'
 ghc-7.10.3:
   ghc: '7.10.3'
   hoopl: '3.10.0.2'
@@ -150,6 +154,7 @@ ghc-7.10.3:
   pretty: '1.1.2.0'
   template-haskell: '2.10.0.0'
   directory: '1.2.2.0'
+  Win32: '2.3.1.0'
 ghc-7.8.4:
   ghc: '7.8.4'
   hoopl: '3.10.0.1'
@@ -180,6 +185,7 @@ ghc-7.8.4:
   pretty: '1.1.1.1'
   template-haskell: '2.9.0.0'
   directory: '1.2.1.0'
+  Win32: '2.3.0.1'
 ghc-8.2.1:
   ghc: '8.2.1'
   hoopl: '3.10.2.2'
@@ -209,6 +215,7 @@ ghc-8.2.1:
   pretty: '1.1.3.3'
   template-haskell: '2.12.0.0'
   directory: '1.3.0.2'
+  Win32: '2.5.4.1'
 ghc-7.10.2:
   ghc: '7.10.2'
   hoopl: '3.10.0.2'
@@ -235,6 +242,7 @@ ghc-7.10.2:
   pretty: '1.1.2.0'
   template-haskell: '2.10.0.0'
   directory: '1.2.2.0'
+  Win32: '2.3.1.0'
 ghc-7.8.3:
   ghc: '7.8.3'
   hoopl: '3.10.0.1'
@@ -265,6 +273,7 @@ ghc-7.8.3:
   pretty: '1.1.1.1'
   template-haskell: '2.9.0.0'
   directory: '1.2.1.0'
+  Win32: '2.3.0.1'
 ghc-8.0.2:
   ghc: '8.0.2'
   hoopl: '3.10.2.1'
@@ -293,6 +302,7 @@ ghc-8.0.2:
   pretty: '1.1.3.3'
   template-haskell: '2.11.1.0'
   directory: '1.3.0.0'
+  Win32: '2.3.1.1'
 ghc-8.4.3:
   ghc: '8.4.3'
   bytestring: '0.10.8.2'
@@ -325,6 +335,7 @@ ghc-8.4.3:
   pretty: '1.1.3.6'
   template-haskell: '2.13.0.0'
   directory: '1.3.1.5'
+  Win32: '2.6.1.0'
 ghc-7.10.1:
   ghc: '7.10.1'
   hoopl: '3.10.0.2'
@@ -351,3 +362,4 @@ ghc-7.10.1:
   pretty: '1.1.2.0'
   template-haskell: '2.10.0.0'
   directory: '1.2.2.0'
+  Win32: '2.3.1.0'


### PR DESCRIPTION
The `Win32` version is taken from the GHC manual for each relevant GHC version.